### PR TITLE
Change fonts for contents and headers

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,5 +1,7 @@
 <!-- start custom head snippets -->
 
+<link href="https://fonts.googleapis.com/css?family=Literata&display=swap" rel="stylesheet">
+
 <!-- insert favicons. use https://realfavicongenerator.net/ -->
 
 <!-- end custom head snippets -->

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -14,7 +14,7 @@ $indent-var: 1.3em !default;
 
 /* system typefaces */
 $serif: Georgia, Times, serif !default;
-$sans-serif: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI",
+$sans-serif: "Literata", -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI",
   "Helvetica Neue", "Lucida Grande", Arial, sans-serif !default;
 $monospace: Monaco, Consolas, "Lucida Console", monospace !default;
 
@@ -30,7 +30,7 @@ $calisto: "Calisto MT", serif !default;
 $garamond: Garamond, serif !default;
 
 $global-font-family: $sans-serif !default;
-$header-font-family: $sans-serif !default;
+$header-font-family: $helvetica !default;
 $caption-font-family: $serif !default;
 
 /* type scale */


### PR DESCRIPTION
Content font now use the "Literata" face font, which I think closely resembles Kindle's "Bookerly" font.

As for the headers, they're now set to use Helvetica.