### PR TITLE
Show social links and icons on author page

### DIFF
--- a/_data/authors/amirulmenjeni.yml
+++ b/_data/authors/amirulmenjeni.yml
@@ -3,10 +3,14 @@ summary: >
   Graduate Development Trainee at Brunei Shell Petroleum assuming
   the role of Sofware and Data Engineer. Also writing for fun in my spare time 📖🖋️.
 links:
-  - label:  "Email"
-    icon:   "fas fa-fw fa-envelope-square"
+  - label:  email
     url:    "mailto:amirulmenjeni@gmail.com"
-  - label:  "Twitter"
-    icon:   "fab fa-fw fa-twitter-square"
+  - label:  twitter
     url:    "https://twitter.com/amirulmenjeni"
+  - label:  goodreads
+    url:    "https://www.goodreads.com/user/show/144747271-amirul-menjeni"
+  - label:  linkedin
+    url:    "https://www.linkedin.com/in/amirul-menjeni-282222154/"
+  - label:  discord
+    url:    "https://discord.gg/Xdmbk3mk"
 permalink: /authors/amirulmenjeni

--- a/_data/mappings/icons.yml
+++ b/_data/mappings/icons.yml
@@ -1,0 +1,10 @@
+normal:
+  twitter:    "fab fa-fw fa-twitter"
+  github:     "fab fa-fw fa-github"
+  email:      "fas fa-fw fa-envelope"
+  linkedin:   "fab fa-fw fa-linkedin"
+  goodreads:  "fab fa-fw fa-goodreads"
+  youtube:    "fab fa-fw fa-youtube"
+  twitch:     "fab fa-fw fa-twitch"
+  instagram:  "fab fa-fw fa-instagram"
+  discord:    "fab fa-fw fa-discord"

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -2,7 +2,23 @@
 layout: single
 ---
 
-<h1>{{ site.data.authors[page.author].name }}</h1>
+<h1>
+  {{ site.data.authors[page.author].name }}
+</h1>
 
-{{ content }}
+<div class="socials">
+  <ul>
+    {% assign sorted_links = site.data.authors[page.author].links | sort: "label" %}
+    {% for link in sorted_links %}
+      <li>
+        <a href="{{ link.url }}">
+          <i class="{{ site.data.mappings.icons.normal[link.label] }}"></i>
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</div>
 
+<div>
+  {{ content }}
+</div>

--- a/_sass/kohack.scss
+++ b/_sass/kohack.scss
@@ -1,0 +1,1 @@
+@import "kohack/socials";

--- a/_sass/kohack/_socials.scss
+++ b/_sass/kohack/_socials.scss
@@ -1,0 +1,16 @@
+.socials {
+
+    margin: 2px;
+    padding: 0px;
+
+    ul {
+
+        padding: 0px;
+
+        li {
+            list-style-type: none;
+            width: auto;
+            display: inline-block;
+        }
+    }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -7,3 +7,4 @@ search: false
 
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials
+@import "kohack";


### PR DESCRIPTION
- This commit also changes the way people add social links to their profile in `_data/authors`. Now they simply provide the `label` and `url` instead of including the css classes for the links.