### PR TITLE
Use consistent icons

### DIFF
--- a/_data/authors/.template.yml
+++ b/_data/authors/.template.yml
@@ -3,8 +3,11 @@ summary: >
   Handsome and muscular.
 
   Also girl magnet.
+
+# link.icon is optional. If not set, it will use the default icon for each
+# correspondiong link.label value in _data/mappings/icons.yml.
 links:
-  - label:  "Email"
+  - label:  email
     icon:   "fas fa-fw fa-envelope-square"
     url:    "mailto:johnny.bravo@gmail.com"
 permalink: /authors/template

--- a/_data/authors/amirulmenjeni.yml
+++ b/_data/authors/amirulmenjeni.yml
@@ -5,18 +5,13 @@ bio: >
 avatar: /assets/images/amirulmenjeni.jpg
 links:
   - label:  email
-    icon:   far fa-envelope 
     url:    "mailto:amirulmenjeni@gmail.com"
   - label:  twitter
-    icon:   fab fa-twitter
     url:    "https://twitter.com/amirulmenjeni"
   - label:  goodreads
-    icon:   fab fa-goodreads
     url:    "https://www.goodreads.com/user/show/144747271-amirul-menjeni"
   - label:  linkedin
-    icon:   fab fa-linkedin 
     url:    "https://www.linkedin.com/in/amirul-menjeni-282222154/"
   - label:  discord
-    icon:   fab fa-discord
     url:    "https://discord.gg/Xdmbk3mk"
 permalink: /authors/amirulmenjeni

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -1,5 +1,6 @@
 {% assign author = page.author | default: page.authors[0] | default: site.author %}
 {% assign author = site.data.authors[author] | default: author %}
+{% assign icons  = site.data.mappings.icons.normal %}
 
 <div itemscope itemtype="https://schema.org/Person" class="h-card">
 
@@ -34,7 +35,7 @@
       {% if author.links %}
         {% for link in author.links %}
           {% if link.label and link.url %}
-            <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer me"{% if link.url contains 'http' %} itemprop="sameAs"{% endif %}><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i><span class="label">{{ link.label }}</span></a></li>
+            <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer me"{% if link.url contains 'http' %} itemprop="sameAs"{% endif %}><i class="{{ link.icon | default: icons[link.label] | default: 'fas fa-link' }}" aria-hidden="true"></i><span class="label">{{ link.label }}</span></a></li>
           {% endif %}
         {% endfor %}
       {% endif %}
@@ -51,7 +52,7 @@
         <li>
           <a href="mailto:{{ author.email }}" rel="me" class="u-email">
             <meta itemprop="email" content="{{ author.email }}" />
-            <i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</span>
+            <i class="{{ icons.email }}" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</span>
           </a>
         </li>
       {% endif %}
@@ -67,7 +68,7 @@
       {% if author.twitter %}
         <li>
           <a href="https://twitter.com/{{ author.twitter }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-            <i class="fab fa-fw fa-twitter-square" aria-hidden="true"></i><span class="label">Twitter</span>
+            <i class="{{ icons.twitter }}" aria-hidden="true"></i><span class="label">Twitter</span>
           </a>
         </li>
       {% endif %}
@@ -83,7 +84,7 @@
       {% if author.linkedin %}
         <li>
           <a href="https://www.linkedin.com/in/{{ author.linkedin }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-            <i class="fab fa-fw fa-linkedin" aria-hidden="true"></i><span class="label">LinkedIn</span>
+            <i class="{{ icons.linkedin }}" aria-hidden="true"></i><span class="label">LinkedIn</span>
           </a>
         </li>
       {% endif %}
@@ -99,7 +100,7 @@
       {% if author.instagram %}
         <li>
           <a href="https://instagram.com/{{ author.instagram }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-            <i class="fab fa-fw fa-instagram" aria-hidden="true"></i><span class="label">Instagram</span>
+            <i class="{{ icons.instagram }}" aria-hidden="true"></i><span class="label">Instagram</span>
           </a>
         </li>
       {% endif %}
@@ -123,7 +124,7 @@
       {% if author.github %}
         <li>
           <a href="https://github.com/{{ author.github }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-            <i class="fab fa-fw fa-github" aria-hidden="true"></i><span class="label">GitHub</span>
+            <i class="{{ icons.github }}" aria-hidden="true"></i><span class="label">GitHub</span>
           </a>
         </li>
       {% endif %}
@@ -188,7 +189,7 @@
         {% if author.youtube contains "://" %}
           <li>
             <a href="{{ author.youtube }}" itemprop="sameAs" rel="nofollow noopener noreferrer me">
-              <i class="fab fa-fw fa-youtube" aria-hidden="true"></i><span class="label">YouTube</span>
+              <i class="{{ icons.youtube }}" aria-hidden="true"></i><span class="label">YouTube</span>
             </a>
           </li>
         {% elsif author.youtube %}


### PR DESCRIPTION
This commit make the author-profile.html view use the icon mappings defined in _data/mappings/icons.yml. The icons set in each author's .yml file can override the mapping.